### PR TITLE
fix: set fix-permissions on jaqpot job image

### DIFF
--- a/data-manager/jobs.yaml
+++ b/data-manager/jobs.yaml
@@ -44,6 +44,7 @@ jobs:
       tag: 'stable'
       project-directory: /data
       working-directory: /data
+      fix-permissions: true
     command: >-
       /code/jaqpot.py
       {% for id in  modelID %}{{ id }} {% endfor %}


### PR DESCRIPTION
## Summary
- The `jaqpot` job's `image` block was missing `fix-permissions: true`. Output files (`predictions.sdf`) were written `-rw-r--r--` (not group-writable), which jote's post-run permission check rejects — every test failed on the permission check even though the job itself ran successfully and produced correct output.
- Added `fix-permissions: true` so the Data Manager (and jote) normalize output file permissions after a successful run, per the [`image` block docs](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/job-definitions.md#the-image-block).

Found while running a full (non-dry-run) `jote` pre-refactor health check across all job submodules in squonk2-jobs.

## Test plan
- [x] Ran `jote --allow-no-tests` from the repo root (real execution, not `--dry-run`) — all 4 tests now pass: `Done (OK) found=4 passed=4 skipped=0 ignored=0 failed=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)