### PR TITLE
fix: bump im-data-manager-job-utilities to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-im-data-manager-job-utilities == 1.2.0
+im-data-manager-job-utilities == 1.3.0
 im-rdkit-utilities == 1.0.0
 annotated-types==0.6.0
 certifi==2023.11.17
@@ -57,7 +57,7 @@ requests==2.31.0
 scikit-learn==1.3.2
 scipy==1.11.4
 seaborn==0.13.0
-six==1.16.0
+six==1.17.0
 skl2onnx==1.15.0
 sympy==1.12
 threadpoolctl==3.2.0


### PR DESCRIPTION
## Summary
Follow-up to #20. `im-rdkit-utilities==1.0.0` hard-pins `im-data-manager-job-utilities==1.3.0`, which conflicted with this repo's existing `==1.2.0` pin and broke the Docker build entirely (`ResolutionImpossible`) — not caught in #20 because I hadn't rebuilt the image locally at review time. Also bumps the transitive `six` pin (`1.16.0` → `1.17.0`) that `1.3.0` requires.

## Test plan
- [x] `docker build` succeeds
- [x] `jote` full suite (smiles/sdf, normal and error-input cases) runs end-to-end against real jaqpotpy models — all 4 tests execute correctly and produce valid predictions (verified SDF output content, including that the error-input cases correctly skip the unparseable molecule rather than crashing)
- [x] The only jote failure is the pre-existing group-permissions check, unrelated to this change (tracked by the separate `fix/output-file-permissions` PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)